### PR TITLE
feat(ci): add pipeline status reporting to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,43 @@ jobs:
           docker logs portfolio-smoke
           docker stop portfolio-smoke
           exit 1
+
+  status:
+    name: "📊 Pipeline Status"
+    needs: [format, build, docker]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report Pipeline Status
+        run: |
+          echo "### 🚦 Pipeline Status Report" >> $GITHUB_STEP_SUMMARY
+          echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "| :--- | :---: |" >> $GITHUB_STEP_SUMMARY
+          
+          status_icon() {
+            case "$1" in
+              success) echo "✅" ;;
+              failure) echo "❌" ;;
+              cancelled) echo "🛑" ;;
+              skipped) echo "⏭️" ;;
+              *) echo "❓" ;;
+            esac
+          }
+          
+          FORMAT_RES="${{ needs.format.result }}"
+          BUILD_RES="${{ needs.build.result }}"
+          DOCKER_RES="${{ needs.docker.result }}"
+          
+          echo "| 🎨 Format check | $(status_icon "$FORMAT_RES") \`$FORMAT_RES\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🏗️ Vite build | $(status_icon "$BUILD_RES") \`$BUILD_RES\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🐳 Docker → GHCR | $(status_icon "$DOCKER_RES") \`$DOCKER_RES\` |" >> $GITHUB_STEP_SUMMARY
+          
+          echo "Format check: $FORMAT_RES"
+          echo "Vite build: $BUILD_RES"
+          echo "Docker → GHCR: $DOCKER_RES"
+          
+          if [ "$FORMAT_RES" != "success" ] || [ "$BUILD_RES" != "success" ] || [ "$DOCKER_RES" != "success" ]; then
+            echo "Pipeline finished with errors or was cancelled."
+            exit 1
+          fi
+


### PR DESCRIPTION
This pull request adds a new job to the GitHub Actions CI workflow that provides a summary report of the pipeline status. The new job collects the results of the format check, build, and Docker jobs, and outputs a markdown summary with status icons. If any of these jobs fail or are cancelled, the pipeline will be marked as failed.

Pipeline status reporting:

* Added a new `status` job to `.github/workflows/ci.yml` that summarizes the results of the `format`, `build`, and `docker` jobs using markdown and status icons in the GitHub Actions summary. The job runs regardless of previous job outcomes and will fail the pipeline if any of the dependent jobs do not succeed.